### PR TITLE
Add table layout detection processor

### DIFF
--- a/marker/converters/pdf.py
+++ b/marker/converters/pdf.py
@@ -35,6 +35,7 @@ from marker.processors.page_header import PageHeaderProcessor
 from marker.processors.reference import ReferenceProcessor
 from marker.processors.sectionheader import SectionHeaderProcessor
 from marker.processors.table import TableProcessor
+from marker.processors.table_layout import TableLayoutProcessor
 from marker.processors.text import TextProcessor
 from marker.processors.block_relabel import BlockRelabelProcessor
 from marker.processors.blank_page import BlankPageProcessor
@@ -84,6 +85,7 @@ class PdfConverter(BaseConverter):
         PageHeaderProcessor,
         SectionHeaderProcessor,
         TableProcessor,
+        TableLayoutProcessor,
         LLMTableProcessor,
         LLMTableMergeProcessor,
         LLMFormProcessor,

--- a/marker/converters/table.py
+++ b/marker/converters/table.py
@@ -10,6 +10,7 @@ from marker.processors.llm.llm_form import LLMFormProcessor
 from marker.processors.llm.llm_table import LLMTableProcessor
 from marker.processors.llm.llm_table_merge import LLMTableMergeProcessor
 from marker.processors.table import TableProcessor
+from marker.processors.table_layout import TableLayoutProcessor
 from marker.providers.registry import provider_from_filepath
 from marker.schema import BlockTypes
 
@@ -17,6 +18,7 @@ from marker.schema import BlockTypes
 class TableConverter(PdfConverter):
     default_processors: Tuple[BaseProcessor, ...] = (
         TableProcessor,
+        TableLayoutProcessor,
         LLMTableProcessor,
         LLMTableMergeProcessor,
         LLMFormProcessor,

--- a/marker/processors/table_layout.py
+++ b/marker/processors/table_layout.py
@@ -1,0 +1,92 @@
+from typing import Annotated, List, Tuple
+
+from marker.processors import BaseProcessor
+from marker.schema import BlockTypes
+from marker.schema.blocks import TableCell
+from marker.schema.document import Document
+from marker.schema.registry import get_block_class
+
+
+class TableLayoutProcessor(BaseProcessor):
+    """Convert tables used for formatting text into standard blocks."""
+
+    block_types: Annotated[Tuple[BlockTypes], "Block types to process."] = (BlockTypes.Table,)
+    max_cell_text_length: Annotated[
+        int,
+        "Average cell text length threshold to treat as a formatting table.",
+    ] = 40
+
+    def is_formatting_table(self, cells: List[TableCell]) -> bool:
+        if not cells:
+            return False
+        row_count = len({c.row_id for c in cells})
+        col_count = len({c.col_id for c in cells})
+        avg_len = sum(len(" ".join(c.text_lines or [])) for c in cells) / len(cells)
+        if row_count == 1 or col_count == 1:
+            return True
+        if row_count <= 2 and col_count <= 2 and avg_len > self.max_cell_text_length:
+            return True
+        return False
+
+    def __call__(self, document: Document):
+        SectionHeader = get_block_class(BlockTypes.SectionHeader)
+        Text = get_block_class(BlockTypes.Text)
+        ListGroup = get_block_class(BlockTypes.ListGroup)
+        ListItem = get_block_class(BlockTypes.ListItem)
+
+        for page in document.pages:
+            for block in page.contained_blocks(document, self.block_types):
+                cells: List[TableCell] = block.contained_blocks(document, (BlockTypes.TableCell,))
+                if not self.is_formatting_table(cells):
+                    continue
+
+                idx = page.structure.index(block.id)
+                page.structure.remove(block.id)
+                block.ignore_for_output = True
+
+                row_count = len({c.row_id for c in cells})
+                col_count = len({c.col_id for c in cells})
+
+                if col_count == 1:
+                    list_group = page.add_full_block(
+                        ListGroup(polygon=block.polygon, page_id=page.page_id)
+                    )
+                    for cell in sorted(cells, key=lambda c: (c.row_id, c.col_id)):
+                        text = " ".join(cell.text_lines or [])
+                        li = page.add_full_block(
+                            ListItem(
+                                polygon=cell.polygon,
+                                page_id=cell.page_id,
+                                html=text,
+                            )
+                        )
+                        list_group.add_structure(li)
+                    page.structure.insert(idx, list_group.id)
+                else:
+                    first_row = min(c.row_id for c in cells)
+                    header_cells = [c for c in cells if c.row_id == first_row]
+                    header_text = " ".join(
+                        " ".join(c.text_lines or []) for c in header_cells
+                    ).strip()
+                    header = page.add_full_block(
+                        SectionHeader(
+                            polygon=header_cells[0].polygon,
+                            page_id=page.page_id,
+                            html=header_text,
+                        )
+                    )
+                    page.structure.insert(idx, header.id)
+
+                    remaining = [c for c in cells if c.row_id != first_row]
+                    if remaining:
+                        text = " ".join(
+                            " ".join(c.text_lines or []) for c in remaining
+                        ).strip()
+                        text_block = page.add_full_block(
+                            Text(
+                                polygon=block.polygon,
+                                page_id=page.page_id,
+                                html=text,
+                            )
+                        )
+                        page.structure.insert(idx + 1, text_block.id)

--- a/tests/processors/test_table_layout_processor.py
+++ b/tests/processors/test_table_layout_processor.py
@@ -1,0 +1,44 @@
+import pytest
+
+from marker.processors.table_layout import TableLayoutProcessor
+from marker.schema import BlockTypes
+from marker.schema.blocks import Table, TableCell
+from marker.schema.groups.page import PageGroup
+from marker.schema.polygon import PolygonBox
+from marker.schema.document import Document
+
+
+def make_polygon(x1, y1, x2, y2):
+    return PolygonBox(polygon=[[x1, y1], [x2, y1], [x2, y2], [x1, y2]])
+
+
+def test_table_layout_processor_list():
+    page = PageGroup(polygon=make_polygon(0, 0, 100, 100), page_id=0, children=[], structure=[])
+    table = Table(polygon=make_polygon(10, 10, 90, 90), page_id=0, structure=[])
+    page.add_full_block(table)
+    page.structure.append(table.id)
+
+    for i, text in enumerate(["A", "B", "C"]):
+        cell = TableCell(
+            polygon=make_polygon(10, 10 + i * 10, 90, 20 + i * 10),
+            text_lines=[text],
+            rowspan=1,
+            colspan=1,
+            row_id=i,
+            col_id=0,
+            is_header=False,
+            page_id=0,
+        )
+        page.add_full_block(cell)
+        table.add_structure(cell)
+
+    document = Document(filepath="", pages=[page])
+    processor = TableLayoutProcessor({})
+    processor(document)
+
+    list_groups = page.contained_blocks(document, (BlockTypes.ListGroup,))
+    assert len(list_groups) == 1
+    list_items = list_groups[0].contained_blocks(document, (BlockTypes.ListItem,))
+    assert len(list_items) == 3
+    assert table.ignore_for_output
+


### PR DESCRIPTION
## Summary
- introduce `TableLayoutProcessor` to convert formatting tables into lists or section headers
- include the processor in PDF and table converters
- add unit test for new table layout processor

## Testing
- `pre-commit` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_686b96cfa7288326a013aa5b873a9a85